### PR TITLE
Fix Renderer FrameRateOptions interval default

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -11,3 +11,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 - android: NDK 26.1.10909125 is used by default
 - android: Minimum API level on Android is now API 21 instead of API 19. This allows the use of OpenGL ES 3.1
 - rendering: New PBR Neutral tone mapper, designed to preserve materials color appearance
+- android: Change default frameRateOptions.interval to 1.0

--- a/android/filament-android/src/main/java/com/google/android/filament/Renderer.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Renderer.java
@@ -101,7 +101,7 @@ public class Renderer {
         /**
          * Desired frame interval in unit of 1 / DisplayInfo.refreshRate.
          */
-        public float interval = 1.0f / 60.0f;
+        public float interval = 1.0f;
 
         /**
          * Additional headroom for the GPU as a ratio of the targetFrameTime.


### PR DESCRIPTION
From https://github.com/google/filament/issues/7539

And I got to the same conclusion based on https://github.com/google/filament/blob/f0f7e299d2ce1a5f3f62821b058353fe00c2015f/filament/src/details/View.cpp#L191

```
        const float target = (1000.0f * float(frameRateOptions.interval)) / displayInfo.refreshRate;
```